### PR TITLE
Add item short description to available email tags

### DIFF
--- a/stripe-payments/admin/class-asp-admin.php
+++ b/stripe-payments/admin/class-asp-admin.php
@@ -1823,6 +1823,7 @@ class AcceptStripePayments_Admin {
 		if ( empty( $email_tags ) ) {
 			$email_tags = array(
 				'{item_name}'         => __( 'Name of the purchased item', 'stripe-payments' ),
+				'{item_short_desc}'   => __( 'Short description of item', 'stripe-payments' ),
 				'{item_quantity}'     => __( 'Number of items purchased', 'stripe-payments' ),
 				'{item_price}'        => __( 'Item price. Example: 1000,00', 'stripe-payments' ),
 				'{item_price_curr}'   => __( 'Item price with currency symbol. Example: $1,000.00', 'stripe-payments' ),

--- a/stripe-payments/includes/process_ipn.php
+++ b/stripe-payments/includes/process_ipn.php
@@ -811,6 +811,7 @@ function asp_apply_dynamic_tags_on_email_body( $body, $post, $seller_email = fal
 
 	$tags = array(
 		'{item_name}',
+		'{item_short_desc}',
 		'{item_quantity}',
 		'{item_url}',
 		'{payer_email}',
@@ -836,6 +837,7 @@ function asp_apply_dynamic_tags_on_email_body( $body, $post, $seller_email = fal
 	);
 	$vals = array(
 		$post['item_name'],
+		$post['charge_description'],
 		$post['item_quantity'],
 		! empty( $post['item_url'] ) ? $post['item_url'] : '',
 		$post['stripeEmail'],


### PR DESCRIPTION
One of the [users requested it](https://s-plugins.com/forums/topic/adding-product-description-to-email-confirmation/) and seems like a valuable addition.